### PR TITLE
added basic support for hdr, Works On My Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The interface is discreet, draggable, always on top, and can be controlled throu
 | Ctrl + H | Toggle overlay visibility           |
 | Ctrl + B | Toggle transparent background       |
 | Ctrl + S | Manually start a timer sequence     |
+| Ctrl + D | Toggle HDR tone mapping             |
 
 ---
 
@@ -74,3 +75,4 @@ pyinstaller --noconsole --onefile --icon=timer.ico --add-data "Tesseract-OCR;Tes
 ## 💬 Support / Suggestions
 
 For feedback, issues, or improvements — feel free to open a GitHub issue or comment on the Nexus Mods page!
+


### PR DESCRIPTION
Did some basic testing with my HDR setup, and found that the screenshot had a peak brightness of 144, so the `THRESH_BINARY_INV` filter was obliterating everything.  Added:

- Linear tone mapping via `cv2.normalize` if "HDR Mode" is enabled
- Flag in `config.txt` to enable HDR Mode (looks for `hdr=True`)
- Hotkey to enable/disable HDR Mode, and save out to config
- Indicator text to show that the program is operating in HDR Mode (so that players don't accidentally miss the DAY text due to not having HDR Mode enabled)

I don't know that `200` is still going to be an appropriate cutoff for `THRESH_BINARY_INV` - it might depend on your setup, or what else is on the screen, I'm not sure - but it worked for me every time in my limited testing.